### PR TITLE
[FIX] Only write pos_ar_id when no one is set in account.invoice

### DIFF
--- a/l10n_ar_point_of_sale/models/invoice.py
+++ b/l10n_ar_point_of_sale/models/invoice.py
@@ -465,7 +465,7 @@ class AccountInvoice(models.Model):
                 self.denomination_id = self.fiscal_position_id.denomination_id
                 sorted_pos = self.denomination_id.pos_ar_ids.sorted(
                     key=lambda x: x.priority)
-                if sorted_pos:
+                if sorted_pos and not self.pos_ar_id:
                     self.pos_ar_id = sorted_pos[0]
             self.local = self.fiscal_position_id.local
         else:


### PR DESCRIPTION
pos_order.action_pos_order_invoice generates a new invoice and then calls to the _onchange_partner_id, if _prepare_invoice has set the pos_ar_id the onchange should not override it.